### PR TITLE
feat(attributes): normalize attributes to an object

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -12,9 +12,31 @@ export class AttributesCustomAttribute {
   }
 
   valueChanged() {
-    Object.keys(this.value).forEach(attribute => {
+    Object.keys(normalizeAtttibutes(this.value)).forEach(attribute => {
       this.element.setAttribute(attribute, this.value[attribute]);
     });
   }
 
+}
+
+/**
+ * @param {object|string|string[]} value
+ * @returns {object} where all the values are strings or boolean
+ */
+function normalizeAtttibutes(value, result = {}) {
+  if (typeof this.value === 'string') {
+    result[this.value] = true;
+
+    return result;
+  }
+
+  if (Array.isArray(this.value)) {
+    this.value.forEach(v => {
+      result = normalizeAtttibutes(v, result);
+    });
+
+    return result;
+  }
+
+  return result;
 }


### PR DESCRIPTION
One can now pass a string, array of strings or an object with string or boolean
values to the attributes form-element property.
