### PR TITLE
feat(validation): enanble aurelia-validation 0.12.x

### DIFF
--- a/src/aurelia-form.js
+++ b/src/aurelia-form.js
@@ -50,22 +50,22 @@ export function configure(aurelia, configOrConfigure) {
       checkboxes: '{{framepath}}/checkboxes',
 
       /* all input components */
-      button: '{{framepath}}/input.html',
-      color: '{{framepath}}/input.html',
-      date: '{{framepath}}/input.html',
-      datetime: '{{framepath}}/input.html',
-      'datetime-local': '{{framepath}}/input.html',
-      string: '{{framepath}}/input.html',
-      email: '{{framepath}}/input.html',
-      month: '{{framepath}}/input.html',
-      number: '{{framepath}}/input.html',
-      password: '{{framepath}}/input.html',
-      range: '{{framepath}}/input.html',
-      search: '{{framepath}}/input.html',
-      tel: '{{framepath}}/input.html',
-      time: '{{framepath}}/input.html',
-      url: '{{framepath}}/input.html',
-      week: '{{framepath}}/input.html'
+      button: '{{framepath}}/input',
+      color: '{{framepath}}/input',
+      date: '{{framepath}}/input',
+      datetime: '{{framepath}}/input',
+      'datetime-local': '{{framepath}}/input',
+      string: '{{framepath}}/input',
+      email: '{{framepath}}/input',
+      month: '{{framepath}}/input',
+      number: '{{framepath}}/input',
+      password: '{{framepath}}/input',
+      range: '{{framepath}}/input',
+      search: '{{framepath}}/input',
+      tel: '{{framepath}}/input',
+      time: '{{framepath}}/input',
+      url: '{{framepath}}/input',
+      week: '{{framepath}}/input'
     }
   });
 

--- a/src/component/framework/bootstrap/checkbox.html
+++ b/src/component/framework/bootstrap/checkbox.html
@@ -10,7 +10,7 @@
           type="checkbox"
           t.bind="label"
           name.bind="element.key"
-          checked.bind="value">
+          checked.bind="model[element.key]">
           ${label}
       </label>
     </div>

--- a/src/component/framework/bootstrap/fieldset.html
+++ b/src/component/framework/bootstrap/fieldset.html
@@ -2,7 +2,7 @@
   <require from="./../../../attributes"></require>
   <fieldset attributes.bind="element.attributes">
     <form-fields
-      model.bind="value"
+      model.bind="model[element.key]"
       schema.bind="element.schema">
     </form-fields>
   </fieldset>

--- a/src/component/framework/bootstrap/input.html
+++ b/src/component/framework/bootstrap/input.html
@@ -8,6 +8,8 @@
       class="form-control"
       type.bind="element.type"
       name.bind="element.key"
-      value.bind="value">
+      value.bind="model[element.key] & validate"
+      blur.trigger = "triggerEvent('blur')"
+      change.trigger = "triggerEvent('change')">
   </form-group>
 </template>

--- a/src/component/framework/bootstrap/input.js
+++ b/src/component/framework/bootstrap/input.js
@@ -1,0 +1,10 @@
+import {inject, DOM} from 'aurelia-framework';
+
+@inject(Element)
+export class InputElement {
+  constructor(element) {
+    this.inputElement = element;
+  }
+
+  triggerEvent = (type) => this.inputElement.dispatchEvent(DOM.createCustomEvent(type));
+}

--- a/src/component/framework/bootstrap/textarea.html
+++ b/src/component/framework/bootstrap/textarea.html
@@ -6,6 +6,6 @@
       attributes.bind="element.attributes"
       class="form-control"
       name.bind="element.key"
-      value.bind="value"></textarea>
+      value.bind="model[element.key]"></textarea>
   </form-group>
 </template>


### PR DESCRIPTION
working proposal
- bind to model[element.key] instead of value to keep the property names (besides there not being much advantage of introducing value in the first place)
- adding & validate to inputs
- delegate blur & change events
