### PR TITLE
chore(project): updated aurelia-cli install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Aurelia-form makes use of `extend`. So, add following to the `build.bundles.depe
     "path": "../node_modules/aurelia-form/dist/amd",
     "main": "aurelia-form",
     "resources": [
+      "attributes.html",
       "component/form-field.html",
       "component/form-fields.html",
       "component/schema-form.html",


### PR DESCRIPTION
Added "attributes.html" to the resources for aurelia-form component installation instruction in aurelia.json. This fixed a bug where /attributes.html was not found when adding the plugin during aurelia bootstrapping stage.