### PR TITLE
doc: change view reference to form attributes

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -54,8 +54,8 @@ export class Page {
 
   <schema-form
     submit.delegate="loginForm.submit(loginForm.credentials)"
-    schema.bind="this.loginForm.schema"
-    model.bind="this.loginForm.credentials"
+    schema.bind="loginForm.schema"
+    model.bind="loginForm.credentials"
   ></schema-form>
 
 <template>


### PR DESCRIPTION
Change the documentation in the aurelia-form docs under "getting
started" and remove the "this" reference in the view. This references
are only necessary in aurelia view-models. This relieves the warning: "the model is undefined" that shows in Chrome developer tools.